### PR TITLE
Fix: only update when needed, titles example

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,11 +375,9 @@ document.addEventListener("click", () => {
 })
 
 ```
-<!-- TODO -->
-  - publishing (vercel, or arweave)
-
-<!-- TODO: rework getting started -->
 ---
+
+<!-- TODO publishing (vercel, or arweave) -->
 
 ## <a name='Examples'></a>Examples
 

--- a/examples/tiles/index.html
+++ b/examples/tiles/index.html
@@ -81,9 +81,11 @@
 
         // Loop over all documents in collection
         for (const documentId in collection) {
-          template += `<div class="document ${documentId}">`
-          const doc = collection[documentId]
 
+          // We are reading directly from olta.state, so need to manually parse each document
+          const doc = olta.parseDoc(collection[documentId])
+
+          template += `<div class="document ${documentId}">`
           // Loop over every property in document
           for (const key in doc) {
             if (key === "_id" || key === "_creator" || key === "_sortKey") {

--- a/lib/olta.js
+++ b/lib/olta.js
@@ -18,6 +18,11 @@ function Olta() {
 
   window.addEventListener("message", (e) => {
     const { state: newState, type } = e.data ?? {}
+
+    if(type !== "state"){
+      return
+    }
+
     state.projectState = newState?.projectState ?? {}
 
     // initiate update handler/ callback

--- a/lib/olta.module.js
+++ b/lib/olta.module.js
@@ -15,6 +15,11 @@ export function Olta() {
 
   window.addEventListener("message", (e) => {
     const { state: newState, type } = e.data ?? {}
+
+    if(type !== "state"){
+      return
+    }
+
     state.projectState = newState?.projectState ?? {}
 
     // initiate update handler/ callback
@@ -53,7 +58,7 @@ export function Olta() {
    */
   function create(collectionId, doc) {
     window.parent.postMessage({
-      type: "create",
+      type: "olta-create",
       collectionId,
       doc : formatDoc(doc)
     }, "*")
@@ -72,7 +77,7 @@ export function Olta() {
    */
   function update(collectionId, doc) {
     window.parent.postMessage({
-      type: "update",
+      type: "olta-update",
       collectionId,
       doc: formatDoc(doc)
     }, "*")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olta/js-sdk",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A small js library that communicates with olta dashboard, making it easy to create decentralized artworks with permanent state changes",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
Fixes a bug with update being called on any message going to the iframe. 

Also fixes tiles example. Manually parsing each document.

Hides part of a TODO that was not meant to be seen