### PR TITLE
Feat: Added changes in the examples initial state and bumped version to upgrade npm package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @olta/js-sdk
+
+## 0.1.0
+
+### Feature Changes
+- Added delete functionality (deleteDoc), that sends a postmessage to delete document by ID.
+- Changed Initial State of examples to include canEvolve and evolve, in order to make contracts deployed upgradable. Also added delete permissions to let only admin (creator) delete docs.

--- a/examples/cuboids/config.js
+++ b/examples/cuboids/config.js
@@ -21,7 +21,9 @@ export const initialState = {
         "create": "closed",
         "createType": "set",
         "update": "open",
-        "updateType": "set"
+        "updateType": "set",
+        "remove": "admin",
+        "removeType": "set"
       }
     }
   },

--- a/examples/rectangles/config.js
+++ b/examples/rectangles/config.js
@@ -42,7 +42,9 @@ export const initialState = {
         "create": "open",
         "createType": "set",
         "update": "open",
-        "updateType": "set"
+        "updateType": "set",
+        "remove": "admin",
+        "removeType": "set"
       }
     }
   },

--- a/examples/tiles/config.js
+++ b/examples/tiles/config.js
@@ -42,7 +42,9 @@ export const initialState = {
         "create": "open",
         "createType": "set",
         "update": "open",
-        "updateType": "set"
+        "updateType": "set",
+        "remove": "admin",
+        "removeType": "set"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olta/js-sdk",
-  "version": "0.0.10",
+  "version": "0.1.0",
   "description": "A small js library that communicates with olta dashboard, making it easy to create decentralized artworks with permanent state changes",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
# @olta/js-sdk

## 0.1.0

### Feature Changes
- Added delete functionality (deleteDoc), that sends a postmessage to delete document by ID.
- Changed Initial State of examples to include canEvolve and evolve, in order to make contracts deployed upgradable. Also added delete permissions to let only admin (creator) delete docs.